### PR TITLE
Bug 4401: Sprint 3-On clicking the Approve/Deny in the fleet access verification page after the user was deleted - Navigates to wrong page instead of Fleet access verification page

### DIFF
--- a/src/app/pages/manage-role/manage-user-role/manage-user-role.component.ts
+++ b/src/app/pages/manage-role/manage-user-role/manage-user-role.component.ts
@@ -41,7 +41,8 @@ public isOrgAdmin: boolean = false;
         this.router.navigateByUrl('manage-users/role/success?data=' + btoa(JSON.stringify(this.userDetails)));
       },
       error: (error: any) => { 
-        this.router.navigateByUrl('manage-users/role/failed');
+        this.userDetails.responce = error
+        this.router.navigateByUrl('manage-users/role/failed?data=' + btoa(JSON.stringify(this.userDetails)));
       },
     });
   }

--- a/src/app/pages/manage-role/role-request-failed/role-request-failed.component.html
+++ b/src/app/pages/manage-role/role-request-failed/role-request-failed.component.html
@@ -1,19 +1,28 @@
-<div
-  class="govuk-error-summary contact-form-error"
-  aria-labelledby="error-summary-title"
-  role="alert"
-  tabindex="-1"
-  id="error-summary"
-  data-module="govuk-error-summary"
->
-  <h2 class="govuk-error-summary__title" id="error-summary-title">
-    {{ "ERROR_SUMMARY" | translate }}
-  </h2>
-  <div class="govuk-error-summary__body">
-    <ul class="govuk-list govuk-error-summary__list">
-      <li>
-        <a href="javascript:;" onClick="return false;">An unexpected error has occurred. Please try again in a few minutes</a>
-      </li>
-    </ul>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+      <div class="user-profile-container">
+          <div class="govuk-breadcrumbs">
+              <ol class="govuk-breadcrumbs__list">
+                  <li class="govuk-breadcrumbs__list-item">
+                      <a *ngIf="isOrgAdmin" class="govuk-breadcrumbs__link" routerLink="/home">
+                          {{ 'ADMINISTRATOR_DASHBOARD' | translate }}
+                      </a>
+                      <a *ngIf="!isOrgAdmin" class="govuk-breadcrumbs__link" routerLink="/home">
+                          {{"PUBLIC_PROCUREMENT_GATEWAY_DASHBOARD" | translate}}
+                      </a>
+                  </li>
+                  <li class="govuk-breadcrumbs__list-item">
+                      <a class="govuk-breadcrumbs__link" (click)="goBack()">Fleet Portal access verification</a>
+                  </li>
+              </ol>
+          </div>
+          <div class="fleet_accept">
+              <h1 class="govuk-heading-xl">Fleet Portal access verification</h1>
+              <p *ngIf="errorCode === 404" class="govuk-body-l">User {{userInfo.userName}} no longer requires access to Fleet Portal and the access
+                has been removed by the organisation admin.</p>
+              <p *ngIf="errorCode !== 404" class="govuk-body-l">An unexpected error has occurred. Please try again in a few minutes</p>
+              <a  href="javascript:;" class="navigation-text" routerLink="/home">Return to dashboard</a>
+          </div>
+      </div>
   </div>
 </div>

--- a/src/app/pages/manage-role/role-request-failed/role-request-failed.component.ts
+++ b/src/app/pages/manage-role/role-request-failed/role-request-failed.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
 
 @Component({
   selector: 'app-role-request-failed',
@@ -7,9 +8,21 @@ import { Component, OnInit } from '@angular/core';
 })
 export class RoleRequestFailedComponent implements OnInit {
 
-  constructor() { }
+  public userInfo:any;
+  public isOrgAdmin: boolean = false;
+  public errorCode: any = '';
+
+  constructor(private ActivatedRoute: ActivatedRoute) { }
 
   ngOnInit(): void {
+    this.ActivatedRoute.queryParams.subscribe((para: any) => {
+      this.userInfo = JSON.parse(atob(para.data));
+      this.errorCode = this.userInfo.responce.status;
+    });
+    this.isOrgAdmin = JSON.parse(localStorage.getItem('isOrgAdmin') || 'false');
   }
 
+  public goBack():void{
+    window.history.back()
+  }
 }


### PR DESCRIPTION
[Bug 4401](https://dev.azure.com/CCS-Conclave/CCS-Conclave_P3/_workitems/edit/4401): Sprint 3-On clicking the Approve/Deny in the fleet access verification page after the user was deleted - Navigates to wrong page instead of Fleet access verification page