### PR TITLE
NPPG-32--Activate-rollbar

### DIFF
--- a/src/environments/environment-NFT.ts
+++ b/src/environments/environment-NFT.ts
@@ -67,7 +67,7 @@ export const environment = {
 
     key: '%ROLLBAR%',
 
-    enable: false,
+    enable: true,
 
     security_log: false,
     

--- a/src/environments/environment-development.ts
+++ b/src/environments/environment-development.ts
@@ -41,7 +41,7 @@ export const environment = {
     mailDecryptKey:'conclavesimpleemailencrypt',
     rollbar: {
       key: '%ROLLBAR%',
-      enable : false,
+      enable : true,
       security_log: false,
       environment: 'dev-ccs-sso'
     },

--- a/src/environments/environment-pre-production.ts
+++ b/src/environments/environment-pre-production.ts
@@ -84,7 +84,7 @@ export const environment = {
   
         key: 'ROLLBAR',
   
-        enable: false,
+        enable: true,
   
         security_log:false,
       

--- a/src/environments/environment-production.ts
+++ b/src/environments/environment-production.ts
@@ -67,7 +67,7 @@ export const environment = {
 
     key: '%ROLLBAR%',
 
-    enable: false,
+    enable: true,
 
     security_log: false,
     

--- a/src/environments/environment-sandbox.ts
+++ b/src/environments/environment-sandbox.ts
@@ -39,7 +39,7 @@ export const environment = {
   mailDecryptKey:'conclavesimpleemailencrypt',  
   rollbar: {
     key: 'ROLLBAR',
-    enable : false,
+    enable : true,
     security_log: false,
     environment: 'sand-ccs-sso'
   },

--- a/src/environments/environment-testing.ts
+++ b/src/environments/environment-testing.ts
@@ -42,7 +42,7 @@ export const environment = {
   mailDecryptKey:'conclavesimpleemailencrypt',
   rollbar: {
         key: '%ROLLBAR%',
-        enable : false,
+        enable : true,
         security_log:false,
         environment: 'test-ccs-sso'
   },

--- a/src/environments/environment-training.ts
+++ b/src/environments/environment-training.ts
@@ -82,7 +82,7 @@ export const environment = {
 
     key: 'ROLLBAR',
 
-    enable: false,
+    enable: true,
 
     security_log:false
 

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -38,7 +38,7 @@ export const environment = {
   mailDecryptKey: '',
   rollbar: {
     key: '',
-    enable: false,
+    enable: true,
     security_log: false,
     environment: 'dev-ccs-sso'
   },


### PR DESCRIPTION
**NPPG-32:**
 - Re-activates the working Rollbar integration (I checked, all looks good code wise).
 - I have re-enabled rollbar across all environment files, even the files that we don't have environments for, like NFT and Sandbox, as this is just a blanket change, since I don't know their deployment process yet, and what file lines up with which running remote environment. For example, I don't know whether Sandbox environment file is used for say Pre-prod, as unlikely as that is. This way, I have covered it so that all running environments will be rollbar enabled and not be missed, and in a worse case scenario enabling it for inactive environments will not do anything, since they aren't running and there is no harm or extra quota usage.