### PR TITLE
NPPG-23--Git-ignore-local-env-file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,6 @@ testem.log
 .DS_Store
 Thumbs.db
 /api/SecurityApi/CcsSso.Security.Api/CcsSso.Security.Api.xml
+
+# Local Secrets File (files here are only used for local development, and not used in any deployments, so won't break our deployment pipeline)
+/src/environments/environment.ts


### PR DESCRIPTION
**NPPG-23:**
 - Done for the UI too. The UI uses environment files, such as `environment.ts` and `environment-<environment>.ts` to contain secrets:

 -- The `environment.ts` is used for local dev only, and contains human readable secrets, and **_does not use placeholders_**. As a result this file can and should be git ignored, which I have deployed as required for this ticket.

 -- The other files `environment-<env>.ts`, (e.g. `environment-production.ts`), are used in the deployment process, but also **_do make use of placeholders_**, so that the real secrets are not exposed, and they are injected from SSM Param Store. As a result these cannot be git ignored, but also don’t need to be.